### PR TITLE
Ensure that non-void functions have return values

### DIFF
--- a/src/allele.cpp
+++ b/src/allele.cpp
@@ -14,7 +14,7 @@ char allele::to_char(alleleValue a) {
       return 'G';
     case gap:
       return '-';
-    case unassigned:
+    default:
       return 'N';
   }
 }

--- a/src/haplotype_state_node.cpp
+++ b/src/haplotype_state_node.cpp
@@ -93,6 +93,7 @@ size_t haplotypeStateNode::node_to_child_index(const haplotypeStateNode* c) cons
       return i;
     }
   }
+  return children.size();
 }
 
 const vector<haplotypeStateNode*>& haplotypeStateNode::get_unordered_children() const {


### PR DESCRIPTION
This is needed to silence compilation warnings/errors on some versions of GCC.